### PR TITLE
Update slim/psr7 dependency to 1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,6 @@
     ],
     "require": {
         "slim/slim": "^4.2",
-        "slim/psr7": "^0.5.0"
+        "slim/psr7": "^1.0"
     }
 }


### PR DESCRIPTION
The actual current tag is v1.3.0, but this is enough to pick up "latest 1.x" rather than using the pre-release tag.